### PR TITLE
Add exported attribute to MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
         android:theme="@style/Theme.Coinkaraokevoicediary"
         tools:targetApi="31">
 
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- mark `MainActivity` as exported in the manifest

## Testing
- `sh gradlew test --no-daemon` *(fails: No route to host while downloading Gradle)*