### PR TITLE
Add audio splitting coroutine utility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/coin_karaoke_voice_diary/audiosplit/AudioSplitter.kt
+++ b/app/src/main/java/com/example/coin_karaoke_voice_diary/audiosplit/AudioSplitter.kt
@@ -1,0 +1,81 @@
+package com.example.coin_karaoke_voice_diary.audiosplit
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.abs
+
+/**
+ * Utility for splitting a PCM WAV byte array by detecting silent sections.
+ */
+object AudioSplitter {
+    /**
+     * Split the given WAV PCM byte array by silence and return each segment as a [ByteArray].
+     *
+     * @param wavBytes WAV file bytes in 16‑bit PCM format.
+     * @param threshold Amplitude considered silent. Defaults to 2000.
+     * @param minSilenceMs Minimum duration of consecutive silence that triggers a split.
+     */
+    suspend fun splitBySilence(
+        wavBytes: ByteArray,
+        threshold: Int = 2000,
+        minSilenceMs: Int = 300
+    ): List<ByteArray> = withContext(Dispatchers.Default) {
+        if (wavBytes.size < 44) return@withContext emptyList()
+
+        // Parse sample rate and bits per sample from WAV header.
+        val sampleRate = ByteBuffer.wrap(wavBytes, 24, 4)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .int
+        val bitsPerSample = ByteBuffer.wrap(wavBytes, 34, 2)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .short.toInt()
+        val bytesPerSample = bitsPerSample / 8
+        val dataOffset = 44 // assume standard header
+        val audioLen = wavBytes.size - dataOffset
+        val minSilenceSamples = (sampleRate * minSilenceMs) / 1000
+
+        var i = 0
+        var segmentStart = 0
+        var silenceCount = 0
+        val segments = mutableListOf<ByteArray>()
+
+        fun readSample(offset: Int): Int = when (bitsPerSample) {
+            16 -> ByteBuffer.wrap(wavBytes, dataOffset + offset, 2)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .short.toInt()
+            else -> wavBytes[dataOffset + offset].toInt()
+        }
+
+        while (i < audioLen) {
+            val sample = abs(readSample(i))
+            if (sample <= threshold) {
+                silenceCount++
+                if (silenceCount >= minSilenceSamples) {
+                    val cutEnd = i - (silenceCount * bytesPerSample) + bytesPerSample
+                    if (segmentStart < cutEnd) {
+                        segments.add(
+                            wavBytes.copyOfRange(dataOffset + segmentStart, dataOffset + cutEnd)
+                        )
+                    }
+                    // skip the silence block
+                    i += bytesPerSample
+                    while (i < audioLen && abs(readSample(i)) <= threshold) {
+                        i += bytesPerSample
+                    }
+                    segmentStart = i
+                    silenceCount = 0
+                    continue
+                }
+            } else {
+                silenceCount = 0
+            }
+            i += bytesPerSample
+        }
+        if (segmentStart < audioLen) {
+            segments.add(wavBytes.copyOfRange(dataOffset + segmentStart, wavBytes.size))
+        }
+        return@withContext segments
+    }
+}

--- a/app/src/test/java/com/example/coin_karaoke_voice_diary/AudioSplitterTest.kt
+++ b/app/src/test/java/com/example/coin_karaoke_voice_diary/AudioSplitterTest.kt
@@ -1,0 +1,54 @@
+package com.example.coin_karaoke_voice_diary
+
+import com.example.coin_karaoke_voice_diary.audiosplit.AudioSplitter
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class AudioSplitterTest {
+
+    private fun generateWav(samples: ShortArray, sampleRate: Int = 8000): ByteArray {
+        val headerSize = 44
+        val bytes = ByteArray(headerSize + samples.size * 2)
+        // RIFF header
+        bytes[0] = 'R'.code.toByte(); bytes[1] = 'I'.code.toByte()
+        bytes[2] = 'F'.code.toByte(); bytes[3] = 'F'.code.toByte()
+        val dataSize = samples.size * 2
+        ByteBuffer.wrap(bytes, 4, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(36 + dataSize)
+        bytes[8] = 'W'.code.toByte(); bytes[9] = 'A'.code.toByte(); bytes[10] = 'V'.code.toByte(); bytes[11] = 'E'.code.toByte()
+        // fmt chunk
+        bytes[12] = 'f'.code.toByte(); bytes[13] = 'm'.code.toByte(); bytes[14] = 't'.code.toByte(); bytes[15] = ' '.code.toByte()
+        ByteBuffer.wrap(bytes, 16, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(16)
+        ByteBuffer.wrap(bytes, 20, 2).order(ByteOrder.LITTLE_ENDIAN).putShort(1) // PCM
+        ByteBuffer.wrap(bytes, 22, 2).order(ByteOrder.LITTLE_ENDIAN).putShort(1) // mono
+        ByteBuffer.wrap(bytes, 24, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(sampleRate)
+        ByteBuffer.wrap(bytes, 28, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(sampleRate * 2)
+        ByteBuffer.wrap(bytes, 32, 2).order(ByteOrder.LITTLE_ENDIAN).putShort(2)
+        ByteBuffer.wrap(bytes, 34, 2).order(ByteOrder.LITTLE_ENDIAN).putShort(16)
+        // data chunk
+        bytes[36] = 'd'.code.toByte(); bytes[37] = 'a'.code.toByte(); bytes[38] = 't'.code.toByte(); bytes[39] = 'a'.code.toByte()
+        ByteBuffer.wrap(bytes, 40, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(dataSize)
+        var offset = headerSize
+        samples.forEach {
+            ByteBuffer.wrap(bytes, offset, 2).order(ByteOrder.LITTLE_ENDIAN).putShort(it)
+            offset += 2
+        }
+        return bytes
+    }
+
+    @Test
+    fun `splitBySilence returns segments`() = runBlocking {
+        val tone = ShortArray(4000) { 10000 }
+        val silence = ShortArray(2000) { 0 }
+        val samples = tone + silence + tone
+        val wav = generateWav(samples)
+
+        val parts = AudioSplitter.splitBySilence(wav, threshold = 500, minSilenceMs = 200)
+        assertEquals(2, parts.size)
+        val expectedBytesPerPart = tone.size * 2
+        assertEquals(expectedBytesPerPart, parts[0].size)
+        assertEquals(expectedBytesPerPart, parts[1].size)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.10.0"
+kotlinxCoroutines = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -15,6 +16,7 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add coroutine-based AudioSplitter to detect silence and cut PCM bytes
- create AudioSplitterTest with generated WAV data
- add kotlinx-coroutines dependency

## Testing
- `./gradlew test` *(fails: could not download Gradle)*