### PR TITLE
Add thumbnailPath column to Recording and update DB version

### DIFF
--- a/app/src/main/java/com/example/coin_karaoke_voice_diary/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/coin_karaoke_voice_diary/data/AppDatabase.kt
@@ -5,13 +5,15 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-@Database(entities = [Recording::class], version = 1, exportSchema = false)
+@Database(entities = [Recording::class], version = 2, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun recordingDao(): RecordingDao
 
     companion object {
         fun create(context: Context): AppDatabase =
-            Room.databaseBuilder(context, AppDatabase::class.java, "recordings.db").build()
+            Room.databaseBuilder(context, AppDatabase::class.java, "recordings.db")
+                .fallbackToDestructiveMigration()
+                .build()
 
         fun createInMemory(context: Context): AppDatabase =
             Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()

--- a/app/src/main/java/com/example/coin_karaoke_voice_diary/data/Recording.kt
+++ b/app/src/main/java/com/example/coin_karaoke_voice_diary/data/Recording.kt
@@ -1,5 +1,6 @@
 package com.example.coin_karaoke_voice_diary.data
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -9,6 +10,7 @@ data class Recording(
     val filePath: String,
   
     /** Local path to a saved thumbnail image for offline use. */
+    @ColumnInfo(name = "thumbnail_path")
     val thumbnailPath: String? = null,
     val title: String,
     val artist: String,

--- a/app/src/main/java/com/example/coin_karaoke_voice_diary/data/RecordingDao.kt
+++ b/app/src/main/java/com/example/coin_karaoke_voice_diary/data/RecordingDao.kt
@@ -10,9 +10,13 @@ interface RecordingDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(recording: Recording): Long
 
-    @Query("SELECT * FROM recordings ORDER BY recordedAt DESC")
+    @Query(
+        "SELECT id, filePath, thumbnail_path, title, artist, recordedAt FROM recordings ORDER BY recordedAt DESC"
+    )
     suspend fun getAll(): List<Recording>
 
-    @Query("SELECT * FROM recordings WHERE id = :id")
+    @Query(
+        "SELECT id, filePath, thumbnail_path, title, artist, recordedAt FROM recordings WHERE id = :id"
+    )
     suspend fun getById(id: Long): Recording?
 }

--- a/app/src/main/java/com/example/coin_karaoke_voice_diary/data/RecordingRepository.kt
+++ b/app/src/main/java/com/example/coin_karaoke_voice_diary/data/RecordingRepository.kt
@@ -1,5 +1,6 @@
 package com.example.coin_karaoke_voice_diary.data
 
+/** Repository wrapper to access [Recording] data including thumbnail paths. */
 class RecordingRepository(private val dao: RecordingDao) {
     suspend fun addRecording(recording: Recording): Long = dao.insert(recording)
 

--- a/app/src/test/java/com/example/coin_karaoke_voice_diary/RecordingDaoTest.kt
+++ b/app/src/test/java/com/example/coin_karaoke_voice_diary/RecordingDaoTest.kt
@@ -43,5 +43,8 @@ class RecordingDaoTest {
         assertEquals("Artist", item.artist)
         assertEquals("path/to/file.wav", item.filePath)
         assertEquals("path/to/thumbnail.jpg", item.thumbnailPath)
+
+        val byId = dao.getById(item.id)
+        assertEquals(item, byId)
     }
 }


### PR DESCRIPTION
## Summary
- add nullable thumbnailPath to Recording entity using `@ColumnInfo`
- bump database version to 2 and allow destructive migration
- explicitly select thumbnail path in DAO queries
- document repository and extend DAO test with `getById`

## Testing
- `./gradlew --offline test` *(fails: No route to host)*