### PR TITLE
Move DAO test to instrumentation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     testImplementation(libs.androidx.room.testing)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.room.testing)
+    androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/app/src/androidTest/java/com/example/coin_karaoke_voice_diary/RecordingDaoTest.kt
+++ b/app/src/androidTest/java/com/example/coin_karaoke_voice_diary/RecordingDaoTest.kt
@@ -1,7 +1,7 @@
 package com.example.coin_karaoke_voice_diary
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.coin_karaoke_voice_diary.data.AppDatabase
 import com.example.coin_karaoke_voice_diary.data.Recording
 import kotlinx.coroutines.runBlocking
@@ -10,12 +10,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+@RunWith(AndroidJUnit4::class)
 class RecordingDaoTest {
     private lateinit var db: AppDatabase
 
     @Before
     fun setup() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
         db = AppDatabase.createInMemory(context)
     }
 


### PR DESCRIPTION
## Summary
- convert `RecordingDaoTest` into an instrumentation test
- use `InstrumentationRegistry` for database creation
- include Room test library for androidTest scope

## Testing
- `./gradlew connectedAndroidTest` *(fails: No route to host during Gradle distribution download)*